### PR TITLE
Remove contexts

### DIFF
--- a/PlainCodeGeneration/PCBlock.class.st
+++ b/PlainCodeGeneration/PCBlock.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'block',
-		'arguments'
+		'arguments',
+		'variables'
 	],
 	#category : #'PlainCodeGeneration-format'
 }
@@ -25,6 +26,21 @@ PCBlock >> block [
 
 { #category : #accessing }
 PCBlock >> block: aBlock [
+	| tempNames receiver |
+	variables := Dictionary new: aBlock outerContext numTemps.
+
+	"get the temps values"
+	tempNames := aBlock outerContext tempNames.
+	1 to: aBlock outerContext numTemps do:[:index|
+		variables at: (tempNames at: index) put: (aBlock outerContext tempNamed: (tempNames at:index)).
+		].
+	
+	"get the instance variables values"
+	receiver := aBlock outerContext receiver.
+	receiver class allInstVarNames do:[:anIVName|
+		variables at: anIVName put: (receiver instVarNamed: anIVName).
+		].
+	
 	block := aBlock
 ]
 
@@ -32,7 +48,7 @@ PCBlock >> block: aBlock [
 PCBlock >> doReplacementsWith: aDictionary [
 	| visitor resAST |
 	visitor := PlainCodeVisitor new
-		context: block outerContext;
+		context: variables ;
 		argumentDictionary:
 			(aDictionary
 				addAll: arguments;
@@ -41,4 +57,14 @@ PCBlock >> doReplacementsWith: aDictionary [
 	resAST := block sourceNode copy.
 	resAST acceptVisitor: visitor.
 	^resAST
+]
+
+{ #category : #accessing }
+PCBlock >> variables [
+	^ variables
+]
+
+{ #category : #accessing }
+PCBlock >> variables: aVariables [
+	variables := aVariables
 ]

--- a/PlainCodeGeneration/PCBlock.class.st
+++ b/PlainCodeGeneration/PCBlock.class.st
@@ -32,8 +32,7 @@ PCBlock >> block: aBlock [
 	"get the temps values"
 	tempNames := aBlock outerContext tempNames.
 	tempNames do:[:aVarName|
-		self halt.
-		variables at: aVarName put: (aBlock outerContext tempNames indexOf: aVarName ).
+		variables at: aVarName put: (aBlock outerContext lookupSymbol: aVarName ).
 		].
 	
 	"get the instance variables values"
@@ -42,7 +41,6 @@ PCBlock >> block: aBlock [
 		variables at: anIVName put: (receiver instVarNamed: anIVName).
 		].
 	self halt.
-	
 	block := aBlock
 ]
 

--- a/PlainCodeGeneration/PCBlock.class.st
+++ b/PlainCodeGeneration/PCBlock.class.st
@@ -31,8 +31,9 @@ PCBlock >> block: aBlock [
 
 	"get the temps values"
 	tempNames := aBlock outerContext tempNames.
-	1 to: aBlock outerContext numTemps do:[:index|
-		variables at: (tempNames at: index) put: (aBlock outerContext tempNamed: (tempNames at:index)).
+	tempNames do:[:aVarName|
+		self halt.
+		variables at: aVarName put: (aBlock outerContext tempNames indexOf: aVarName ).
 		].
 	
 	"get the instance variables values"
@@ -40,6 +41,7 @@ PCBlock >> block: aBlock [
 	receiver class allInstVarNames do:[:anIVName|
 		variables at: anIVName put: (receiver instVarNamed: anIVName).
 		].
+	self halt.
 	
 	block := aBlock
 ]

--- a/PlainCodeGeneration/PCBlock.class.st
+++ b/PlainCodeGeneration/PCBlock.class.st
@@ -40,7 +40,7 @@ PCBlock >> block: aBlock [
 	receiver class allInstVarNames do:[:anIVName|
 		variables at: anIVName put: (receiver instVarNamed: anIVName).
 		].
-	self halt.
+
 	block := aBlock
 ]
 

--- a/PlainCodeGeneration/PCBlocks.class.st
+++ b/PlainCodeGeneration/PCBlocks.class.st
@@ -23,8 +23,8 @@ PCBlocks >> add: aBlock withArguments: args [
 	blocks
 		add:
 			(PCBlock new
-				block: aBlock;
-				arguments: args;
+				block: aBlock ;
+				arguments: args ;
 				yourself)
 ]
 
@@ -62,7 +62,7 @@ PCBlocks >> asMethod: aSelector withArguments: aDictionary [
 	| blockAST |
 	blockAST := self asBlock: aDictionary.
 	
-	^RBMethodNode  selector: aSelector arguments: blockAST arguments body: blockAST body
+	^ RBMethodNode  selector: aSelector arguments: blockAST arguments body: blockAST body
 ]
 
 { #category : #ast }

--- a/PlainCodeGeneration/PlainCodeVisitor.class.st
+++ b/PlainCodeGeneration/PlainCodeVisitor.class.st
@@ -88,7 +88,7 @@ PlainCodeVisitor >> getMessageSelector: aString [
 
 { #category : #visiting }
 PlainCodeVisitor >> getReplacementName: aString [
-	(context lookupSymbol: aString)
+	(context at: aString ifAbsent:[ ^ aString ])
 		ifNotNil: [ :value | 
 			(value isCollection and:[ value isString not])
 				ifTrue: [ ^ value ]
@@ -150,7 +150,7 @@ PlainCodeVisitor >> variableExpandsInMultipleVariables: aNode [
 	omm:=aNode parent outerMostMessage.
 	omm parent isReturn ifTrue:[^ExpandReturnError new signal].
 	
-	res:=(context lookupSymbol: aNode name) collect:[:aStatement| 
+	res:=(context at: aNode name ifAbsent:[nil]) collect:[:aStatement| 
 		omm copy innerMostMessage receiver: (RBVariableNode named:aStatement)
 		].
 	omm parent replaceNode: omm withNodes: res.
@@ -160,7 +160,7 @@ PlainCodeVisitor >> variableExpandsInMultipleVariables: aNode [
 PlainCodeVisitor >> variablesNodesVisit: aNode [
 	"visits for IV/argument/temporary nodes"
 	| resolvedVariable |
-	resolvedVariable := context lookupSymbol: aNode name.
+	resolvedVariable := context at: aNode name ifAbsent:[ nil ].
 	resolvedVariable isNil
 		ifTrue: [ ^ self ].
 	resolvedVariable isArray
@@ -196,7 +196,7 @@ PlainCodeVisitor >> visitAssignmentNode: anAssignmentNode [
 
 	anAssignmentNode value acceptVisitor:self.
 
-	resolvedName := context lookupSymbol: anAssignmentNode variable name.
+	resolvedName := context at: anAssignmentNode variable name ifAbsent:[ nil ].
 	resolvedName ifNil:[ ^self ].
 	
 	resolvedName isArray ifFalse:[resolvedName := { resolvedName } ].
@@ -224,7 +224,7 @@ PlainCodeVisitor >> visitMessageNode: aMessageNode [
 	super visitMessageNode: aMessageNode.
 	
 	newSelector := self getMessageSelector: aMessageNode selector.
-
+	
 	(newSelector isCollection and:[ newSelector isString not])
 		ifFalse: [ 
 			newSelector = aMessageNode selector
@@ -246,6 +246,11 @@ PlainCodeVisitor >> visitMessageNode: aMessageNode [
 			"Else, needs to be expanded"
 			newSelector
 				ifNotEmpty: [ self message: aMessageNode expandInMultipleSelectors: newSelector ] ]
+]
+
+{ #category : #visiting }
+PlainCodeVisitor >> visitSequenceNode: aMethodNode [
+	super visitSequenceNode: aMethodNode 
 ]
 
 { #category : #visiting }

--- a/PlainCodeGeneration/RBProgramNode.extension.st
+++ b/PlainCodeGeneration/RBProgramNode.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #RBProgramNode }
+
+{ #category : #'*PlainCodeGeneration' }
+RBProgramNode >> statement [
+	
+]

--- a/PlainCodeGeneration/RBReturnNode.extension.st
+++ b/PlainCodeGeneration/RBReturnNode.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #RBReturnNode }
+
+{ #category : #'*PlainCodeGeneration' }
+RBReturnNode >> statement [
+	^ self parent isSequence ifTrue:[ self ] ifFalse:[ self parent ]
+]

--- a/PlainCodeGeneration/RBValueNode.extension.st
+++ b/PlainCodeGeneration/RBValueNode.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #RBValueNode }
+
+{ #category : #'*PlainCodeGeneration' }
+RBValueNode >> statement [
+	^ self parent isSequence ifTrue:[ self ] ifFalse:[ self parent ]
+]


### PR DESCRIPTION
Store variables in a dictionary when adding a block.
Allows to reuse variables, and to use the state at the creation of the block to achieve the replacements.
Still problems in P7, works well in P8 as described in #15 .